### PR TITLE
Add Entity Framework Core support with SQLite

### DIFF
--- a/ColiTool.Database/AppDbContext.cs
+++ b/ColiTool.Database/AppDbContext.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace ColiTool.Database
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        {
+        }
+        //define DbSets (tables) here
+        public DbSet<Entities.TestEntity> TestEntities { get; set; }
+    }
+}

--- a/ColiTool.Database/Class1.cs
+++ b/ColiTool.Database/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace ColiTool.Database
-{
-    public class Class1
-    {
-
-    }
-}

--- a/ColiTool.Database/Entities/TestEntity.cs
+++ b/ColiTool.Database/Entities/TestEntity.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ColiTool.Database.Entities
+{
+    public class TestEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/ColiTool.WebAPI/ColiTool.WebAPI.csproj
+++ b/ColiTool.WebAPI/ColiTool.WebAPI.csproj
@@ -7,7 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ColiTool.Database\ColiTool.Database.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ColiTool.WebAPI/ColiTool.WebAPI.csproj
+++ b/ColiTool.WebAPI/ColiTool.WebAPI.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
+	 <ProjectReference Include="..\ColiTool.CanBus\ColiTool.CanBus.csproj" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/ColiTool.WebAPI/Program.cs
+++ b/ColiTool.WebAPI/Program.cs
@@ -1,3 +1,6 @@
+using ColiTool.Database;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -5,6 +8,11 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+//Configure DbContext with SQLite
+builder.Services.AddDbContext<AppDbContext>(options =>
+       options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
+
 
 var app = builder.Build();
 

--- a/ColiTool.WebAPI/appsettings.json
+++ b/ColiTool.WebAPI/appsettings.json
@@ -1,9 +1,13 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+
+    "ConnectionStrings": {
+        "DefaultConnection": "Data Source=Database/colitool.db"
     }
-  },
-  "AllowedHosts": "*"
 }


### PR DESCRIPTION
- Implemented `AppDbContext` for database management.
- Created `TestEntity` class for database representation.
- Removed unused `Class1` class.
- Updated project file to include EF Core and SQLite packages.
- Configured `Program.cs` for `AppDbContext` and connection string.
- Added SQLite connection string in `appsettings.json`.